### PR TITLE
Resolve Paths before Yielding to Decompiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ cd apkscan
 python3 -m venv .venv
 source .venv/bin/activate
 pip3 install -e .
+cd ../
 ```
 
 ---
@@ -112,11 +113,11 @@ apkscan file-to-scan.apk -r aws endpoints
 
 A slighly more complex example. This time 3 APKs will be decompiled then scanned using the custom rules at `/path/to/custom/rules.json`. The output written to `output_file.yaml` in `YAML` format, and the results will be grouped by which secret locator was matched. Files generated during decompilation will be removed after scanning.
 ```bash
-apkscan -r /path/to/custom/rules.json -o output_file.yaml -f yaml -g locator -c
+apkscan -r /path/to/custom/rules.json -o output_file.yaml -f yaml -g locator -c file1.apk file2.apk file3.apk
 ```
 Or in long form:
 ```bash
-apkscan --rules /path/to/custom/rules.json --output output_file.yaml --format yaml --groupby locator --cleanup
+apkscan --rules /path/to/custom/rules.json --output output_file.yaml --format yaml --groupby locator --cleanup file1.apk file2.apk file3.apk
 ```
 ---
 

--- a/src/apkscan/apkscan.py
+++ b/src/apkscan/apkscan.py
@@ -94,7 +94,7 @@ class APKScanner:
                 print(f"\nDecompiling started at {self.decompile_start_time.strftime('%H:%M:%S:%SS')}\n")
 
             self.print_status()
-            yield file_path
+            yield file_path.resolve()
 
     def decompiled_files_generator(self, file_paths: Iterable[Path]) -> Generator[Path, None, None]:
         for file_path, output_dir, decompiled_files, success in self.decompiler.decompile_concurrently(file_paths):


### PR DESCRIPTION
- Resolve input paths before yielding to decompiler so if a relative path is seen it is processed by the decompiler as its absolute path. Should fix #1 
- Update readme to cd ../ after install from source to discourage running from within the repo dir
- Fix multiple input file command examples