### PR TITLE
Allow TOML only if tomllib is available. (Python >3.11)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ build-backend = "setuptools.build_meta"
 authors = [{name = "Lucas Faudman", email = "lucasfaudman@gmail.com"}]
 dynamic = ["classifiers"]
 name = "apkscan"
-version = "0.3.9"
-requires-python = ">=3.11"
+version = "0.4.0"
+requires-python = ">=3.10"
 readme = "README.md"
 license = { file = "LICENSE" }
 description = "Scan for secrets, endpoints, and other sensitive data after decompiling and deobfuscating Android files. (.apk, .xapk, .dex, .jar, .class, .smali, .zip, .aar, .arsc, .aab, .jadx.kts)"
@@ -20,6 +20,7 @@ keywords = [
 dependencies = [
     "enjarify-adapter",
     "pyyaml",
+    "toml",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ keywords = [
 dependencies = [
     "enjarify-adapter",
     "pyyaml",
-    "toml",
 ]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ except Exception as e:
 
 setup(
     name="apkscan",
-    version="0.3.9",
+    version="0.4.0",
     use_scm_version=True,
     setup_requires=["setuptools>=42", "setuptools_scm>=8", "wheel"],
     description="Scan for secrets, endpoints, and other sensitive data after decompiling and deobfuscating Android files. (.apk, .xapk, .dex, .jar, .class, .smali, .zip, .aar, .arsc, .aab, .jadx.kts)",
@@ -40,10 +40,7 @@ setup(
     },
     include_package_data=True,
     exclude_package_data={"": [".gitignore", ".pre-commit-config.yaml"]},
-    install_requires=[
-        "enjarify-adapter",
-        "pyyaml",
-    ],
+    install_requires=["enjarify-adapter", "pyyaml", "toml"],
     ext_modules=EXT_MODULES,
     cmdclass={"build_ext": build_ext},
     extras_require={
@@ -57,13 +54,14 @@ setup(
             "apkscan = apkscan.main:main",
         ],
     },
-    python_requires=">=3.11",
+    python_requires=">=3.10",
     license="LICENSE",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Operating System :: OS Independent",

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     },
     include_package_data=True,
     exclude_package_data={"": [".gitignore", ".pre-commit-config.yaml"]},
-    install_requires=["enjarify-adapter", "pyyaml", "toml"],
+    install_requires=["enjarify-adapter", "pyyaml"],
     ext_modules=EXT_MODULES,
     cmdclass={"build_ext": build_ext},
     extras_require={

--- a/src/apkscan/main.py
+++ b/src/apkscan/main.py
@@ -23,7 +23,7 @@ BANNER_ART = """\033[1;32m   ('-.      _ (`-. .-. .-')   .-')             ('-.  
   `--' `--'`--'     `--' '--' `-----'  `-----' `--' `--'`--'  `--'   """
 
 BANNER_TEXT = """
-  \033[1;92mAPKscan v0.3.9 - \033[3mScan for secrets, endpoints, and other sensitive data
+  \033[1;92mAPKscan v0.4.0 - \033[3mScan for secrets, endpoints, and other sensitive data
   after decompiling and deobfuscating Android files.\033[0m\033[0;92m
   (.apk, .xapk, .dex, .jar, .class, .smali, .zip, .aar, .arsc, .aab, .jadx.kts)
 

--- a/src/apkscan/secret_scanner.py
+++ b/src/apkscan/secret_scanner.py
@@ -21,11 +21,13 @@ from yaml import safe_load as yaml_safe_load, YAMLError  # type: ignore
 from json import loads as json_loads, JSONDecodeError
 
 try:
-    # Use built-in tomllib if python 3.11+ otherwise use toml package
+    # Use built-in tomllib if python 3.11+ otherwise ignore TOML files
     from tomllib import loads as toml_loads, TOMLDecodeError
+
+    TOML_SUPPORTED = True
 except ImportError:
-    from toml import loads as toml_loads
-    from toml import TomlDecodeError as TOMLDecodeError
+    print("tomllib not found. TOML files will be ignored. Use Python 3.11+ to enable TOML support.")
+    TOML_SUPPORTED = False
 
 from .concurrent_executor import ConcurrentExecutor
 from .included_secret_locators import INCLUDED_SECRET_LOCATOR_FILES  # type: ignore
@@ -80,10 +82,11 @@ def try_load_json_toml_yaml(file_path: Path) -> Optional[dict | list]:
     except JSONDecodeError:
         print(f"Error loading {file_path} as JSON. Trying TOML.")
 
-    try:
-        return toml_loads(contents)
-    except TOMLDecodeError:
-        print(f"Error loading {file_path} as TOML. Trying YAML.")
+    if TOML_SUPPORTED:
+        try:
+            return toml_loads(contents)
+        except TOMLDecodeError:
+            print(f"Error loading {file_path} as TOML. Trying YAML.")
 
     try:
         return yaml_safe_load(contents)

--- a/src/apkscan/secret_scanner.py
+++ b/src/apkscan/secret_scanner.py
@@ -1,9 +1,6 @@
 # © 2023 Lucas Faudman.
 # Licensed under the MIT License (see LICENSE for details).
 # For commercial use, see LICENSE for additional terms.
-from yaml import safe_load as yaml_safe_load, YAMLError  # type: ignore
-from json import loads as json_loads, JSONDecodeError
-from tomllib import loads as toml_loads, TOMLDecodeError
 from dataclasses import dataclass, field
 from typing import Optional, Iterator, Tuple
 from pathlib import Path
@@ -19,6 +16,16 @@ from re import (
     VERBOSE,
     TEMPLATE,
 )
+
+from yaml import safe_load as yaml_safe_load, YAMLError  # type: ignore
+from json import loads as json_loads, JSONDecodeError
+
+try:
+    # Use built-in tomllib if python 3.11+ otherwise use toml package
+    from tomllib import loads as toml_loads, TOMLDecodeError
+except ImportError:
+    from toml import loads as toml_loads
+    from toml import TomlDecodeError as TOMLDecodeError
 
 from .concurrent_executor import ConcurrentExecutor
 from .included_secret_locators import INCLUDED_SECRET_LOCATOR_FILES  # type: ignore

--- a/tests/test_secret_scanner.py
+++ b/tests/test_secret_scanner.py
@@ -20,7 +20,8 @@ def test_load_all_formats(tmp_locator_files, locator_file):
     "locator_file", ["secret_patterns_db.yml", "gitleaks.toml", "secret_locators.json", "simple_key_value.json"]
 )
 def test_scan_files(tmp_locator_files, tmp_files_to_scan, locator_file):
-    scanner = SecretScanner([tmp_locator_files[locator_file]])
+    scanner = SecretScanner()
+    scanner.load_secret_locators([tmp_locator_files[locator_file]])
     results = list(scanner.scan_concurrently(tmp_files_to_scan.values()))
     assert isinstance(results, list)
     for file_path, file_secret_results in results:


### PR DESCRIPTION
- Allow TOML only if tomllib is available. (Python >3.11)
- Set min version to Python 3.10 since tomllib is no longer required.