### PR TITLE
Removed Depreciated TEMPLATE From 'secret_scanner.py'

### DIFF
--- a/src/apkscan/secret_scanner.py
+++ b/src/apkscan/secret_scanner.py
@@ -14,7 +14,6 @@ from re import (
     LOCALE,
     UNICODE,
     VERBOSE,
-    TEMPLATE,
 )
 
 from yaml import safe_load as yaml_safe_load, YAMLError  # type: ignore


### PR DESCRIPTION
Function re.template and const re.TEMPLATE have been removed in python 3.13 not allowing the script to run with the latest versions of python.